### PR TITLE
Adapt cal-pulser code for new hardware revision (N)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ endif
 
 #check if inside rno-g-revn yocto build
 ifneq (,$(filter ${MACHINE},rno-g-revn))
+$(info We are inside yocto)
+ON_AM62X=yes
+endif
+
+#check if on revn board
+ifneq (,$(shell grep RevN /proc/device-tree/model 2> /dev/null))
+$(info We are on the RevN DAQ)
 ON_AM62X=yes
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,34 @@ CXXFLAGS+=-fPIC -Og -Wall -Wextra -g
 #CFLAGS+=-DRADIANT_SET_DBG
 
 ON_BBB?=no
+ON_AM62X?=no
 
 # are we (probably) on the BBB?
 ifeq ($(shell uname -m),armv7l)
 ON_BBB=yes
 endif
 
+
 ifeq ($(ON_BBB),yes)
 $(info We are on the DAQ)
 CFLAGS+=-mfpu=neon
 CFLAGS+=-DON_BBB
 endif
+
+#check if inside rno-g-revn yocto build
+ifneq (,$(filter ${MACHINE},rno-g-revn))
+ON_AM62X=yes
+endif
+
+
+ifeq ($(ON_AM62X),yes)
+	CFLAGS+=-mfpu=neon
+	CFLAGS+=-DON_AM62X
+	CFLAGS+=-DUSE_LIBGPIOS
+	LDFLAGS+=-lgpios
+endif
+
+
 
 LDFLAGS=-shared
 LIBS=-lz -pthread

--- a/src/rno-g-cal.c
+++ b/src/rno-g-cal.c
@@ -46,11 +46,11 @@ const uint8_t addr0 = 0x38;
 const uint8_t addr1 = 0x3f;
 #ifdef USE_LIBGPIOS
 const uint8_t addr2 = 0x19; //temp sensor
-const uint8_t addr_hum = 0x40; //humidity sensor
 #else
 const uint8_t addr2 = 0x18; //temp sensor
 #endif
-
+const uint8_t addr_hum = 0x40; //humidity sensor for simplicity always defined, only used for revN == USE_LIBGPIOS
+const uint8_t TRIGGER_HUMIDITY_MEASURE_NO_HOLD = 0xF5;
 
 const uint8_t output_reg = 0x01;
 const uint8_t config_reg = 0x03;
@@ -322,6 +322,58 @@ static int do_read(rno_g_cal_dev_t *dev, uint8_t addr, uint8_t reg, uint8_t * va
   return do_readv(dev, addr, reg, 1, val);
 }
 
+// write a single raw command byte (no separate register byte), e.g. for the humidity sensor
+static int do_write_cmd(rno_g_cal_dev_t * dev, uint8_t addr, uint8_t cmd)
+{
+  if (!dev) return 1;
+  struct i2c_msg msg = { .addr = addr, .flags = 0, .len = sizeof(cmd), .buf = &cmd };
+
+  if (dev->debug)
+  {
+    printf("DBG: do_write_cmd(.addr=0x%02x, .cmd=0x%02x)\n", addr, cmd);
+  }
+
+  struct i2c_rdwr_ioctl_data i2c_data = {.msgs = &msg, .nmsgs = 1 };
+
+  if (ioctl(dev->fd, I2C_RDWR, &i2c_data) < 0 )
+  {
+    return -errno;
+  }
+
+  return 0;
+}
+
+// read N raw bytes with no register byte sent first (e.g. for the humidity sensor)
+static int do_readv_raw(rno_g_cal_dev_t * dev, uint8_t addr, int N, uint8_t * data)
+{
+  if (!dev) return 1;
+  struct i2c_msg msg = { .addr = addr, .flags = I2C_M_RD, .len = N, .buf = data };
+
+  if (dev->debug)
+  {
+    printf("DBG: do_readv_raw(.addr=0x%02x, .len=%d)\n", addr, N);
+  }
+
+  struct i2c_rdwr_ioctl_data i2c_data = {.msgs = &msg, .nmsgs = 1 };
+
+  if (ioctl(dev->fd, I2C_RDWR, &i2c_data) < 0 )
+  {
+    return -errno;
+  }
+
+  if (dev->debug)
+  {
+    printf("  read: ");
+    for (int i = 0; i < N; i++)
+    {
+      printf ("0x%02x ", data[i]);
+    }
+    printf("\n");
+  }
+
+  return 0;
+}
+
 
 int rno_g_cal_setup(rno_g_cal_dev_t* dev)
 {
@@ -569,6 +621,38 @@ int rno_g_cal_read_temp(rno_g_cal_dev_t *dev, float *Tout)
   return 0;
 
 }
+
+int rno_g_cal_read_humidity(rno_g_cal_dev_t *dev, float *humidity)
+{
+  if (!dev) return 1;
+  if (dev->rev < 'N')
+  {
+    if (humidity) *humidity = -1;
+    return 0;
+  }
+
+  // Send humidity measurement command (no-hold master mode)
+  if (do_write_cmd(dev, addr_hum, TRIGGER_HUMIDITY_MEASURE_NO_HOLD)) return -errno;
+
+  // Wait for conversion (~20ms typical)
+  usleep(50000);
+
+  uint8_t data[3];
+  if (do_readv_raw(dev, addr_hum, sizeof(data), data)) return -errno;
+
+  uint16_t raw = (data[0] << 8) | data[1];
+
+  // Clear status bits
+  raw &= 0xFFFC;
+
+  // Convert to %RH using datasheet formula
+  if (humidity)
+    *humidity = -6 + (125.0 * raw / 65536.0);
+
+  return 0;
+
+}
+
 
 void rno_g_cal_enable_dbg(rno_g_cal_dev_t * dev, int dbg)
 {

--- a/src/rno-g-cal.c
+++ b/src/rno-g-cal.c
@@ -347,15 +347,12 @@ int rno_g_cal_set_pulse_mode(rno_g_cal_dev_t *dev, rno_g_calpulser_mode_t type)
   uint8_t val;
   if (!dev) return 1;
 
-  if (dev->setup && dev->mode == type) return 0;
+  if (dev->setup && dev->mode == type) return 0;  // Also return if type == RNO_G_CAL_NO_SIGNAL
 
   if (do_read(dev, addr1, output_reg, &val))
   {
     return -errno;
   }
-
-  if (type == RNO_G_CAL_NO_SIGNAL)
-    return 0;  // Do nothing?
 
   if (type == RNO_G_CAL_PULSER)
   {

--- a/src/rno-g-cal.c
+++ b/src/rno-g-cal.c
@@ -43,7 +43,14 @@ const char valid_revs[] = "DEF";
 
 const uint8_t addr0 = 0x38;
 const uint8_t addr1 = 0x3f;
+#ifdef USE_LIBGPIOS
+const uint8_t addr2 = 0x19; //temp sensor
+const uint8_t addr_hum = 0x40; //humidity sensor
+#else
 const uint8_t addr2 = 0x18; //temp sensor
+#endif
+
+
 const uint8_t output_reg = 0x01;
 const uint8_t config_reg = 0x03;
 const uint8_t tmp_reg = 0x05;
@@ -67,9 +74,9 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
     rev = toupper(rev);
   }
 
-  if (!strchr(valid_revs,rev))
+  if (!strchr(valid_revs, rev))
   {
-    fprintf(stderr,"rev%c is not valid!\n", rev);
+    fprintf(stderr, "rev%c is not valid!\n", rev);
     return NULL;
   }
 
@@ -78,7 +85,7 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
 #ifndef USE_LIBGPIOS
   // make sure we have the gpio exported
   char * gpio_dir = 0;
-  asprintf(&gpio_dir,gpio_dir_format, gpio);
+  asprintf(&gpio_dir, gpio_dir_format, gpio);
 
 // lazy code
   if (access(gpio_dir, W_OK))
@@ -106,7 +113,7 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
   }
 
 #endif
-  snprintf(fname,sizeof(fname)-1, "/dev/i2c-%hhu", bus);
+  snprintf(fname, sizeof(fname)-1, "/dev/i2c-%hhu", bus);
 
   int fd = open(fname, O_RDWR);
 
@@ -117,7 +124,7 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
     return NULL;
   }
 
-  rno_g_cal_dev_t * dev = calloc(1,sizeof(rno_g_cal_dev_t));
+  rno_g_cal_dev_t * dev = calloc(1, sizeof(rno_g_cal_dev_t));
 
   if (!dev)
   {
@@ -125,9 +132,6 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
     close(fd);
     return NULL;
   }
-
-
-
 
 #ifndef LIBGPIOS_H
   //open the gpio file
@@ -167,7 +171,6 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
 #else
   memcpy(&dev->gpio,&line, sizeof(line);
 #endif
-
 
   dev->fd = fd;
   dev->rev = rev;
@@ -223,7 +226,7 @@ int rno_g_cal_disable_no_handle(uint16_t gpio)
 #ifdef USE_LIBGPIOS
   gpios_line_t line;
   //open as an input, that will turn it off :)
-  int ok = gpios_get_line_by_label("CAL_EN", &line, 0); 
+  int ok = gpios_get_line_by_label("CAL_EN", &line, 0);
   gpios_release(&line);
   return ok;
 #else

--- a/src/rno-g-cal.c
+++ b/src/rno-g-cal.c
@@ -14,6 +14,11 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#ifdef USE_LIBGPIOS
+#include "libgpios.h"
+#endif
+
+
 struct rno_g_cal_dev
 {
   int fd;
@@ -26,8 +31,12 @@ struct rno_g_cal_dev
   uint8_t atten;
   int enabled;
   int setup;
+#ifdef USE_LIBGPIOS
+  gpios_line_t gpio;
+#else
   FILE * fgpiodir;
   FILE * fgpioval;
+#endif
 };
 
 const char valid_revs[] = "DEF";
@@ -39,8 +48,10 @@ const uint8_t output_reg = 0x01;
 const uint8_t config_reg = 0x03;
 const uint8_t tmp_reg = 0x05;
 
+#ifndef USE_LIBGPIOS
 const char gpio_dir_format[] = "/sys/class/gpio/gpio%hu/direction";
 const char gpio_val_format[] = "/sys/class/gpio/gpio%hu/value";
+#endif
 
 
 rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
@@ -62,6 +73,9 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
     return NULL;
   }
 
+
+
+#ifndef USE_LIBGPIOS
   // make sure we have the gpio exported
   char * gpio_dir = 0;
   asprintf(&gpio_dir,gpio_dir_format, gpio);
@@ -80,6 +94,18 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
     fclose(f);
     usleep(150000); // long enough?
   }
+
+#else
+  (void) gpio;
+  gpios_line_t line;
+  int ok = gpios_get_line_by_label("CAL_EN", &line, GPIOS_OUTPUT);
+  if (ok)
+  {
+    fprintf("Could not open GPIO CAL_EN\n",);
+    return NULL;
+  }
+
+#endif
   snprintf(fname,sizeof(fname)-1, "/dev/i2c-%hhu", bus);
 
   int fd = open(fname, O_RDWR);
@@ -103,6 +129,7 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
 
 
 
+#ifndef LIBGPIOS_H
   //open the gpio file
   FILE * fgpio = fopen(gpio_dir,"w");
   if (!fgpio)
@@ -137,6 +164,11 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
   setbuf(fval,0);
   dev->fgpiodir = fgpio;
   dev->fgpioval = fval;
+#else
+  memcpy(&dev->gpio,&line, sizeof(line);
+#endif
+
+
   dev->fd = fd;
   dev->rev = rev;
   dev->bus = bus;
@@ -151,8 +183,12 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
 int rno_g_cal_close(rno_g_cal_dev_t * dev)
 {
   if (!dev) return -1;
+#ifdef USE_LIBGPIOS
+  gpios_release(&dev->gpio);
+#else
   fclose(dev->fgpiodir);
   fclose(dev->fgpioval);
+#endif
   close(dev->fd);
   free(dev);
   return 0;
@@ -162,18 +198,35 @@ int rno_g_cal_enable(rno_g_cal_dev_t * dev)
 {
   if (!dev) return 1;
   dev->enabled = 1;
+#ifdef USE_LIBGPIOS
+  return gpios_set_value(&dev->gpio,true);
+#else
   return (fprintf(dev->fgpiodir,"out\n") != sizeof("out\n")-1) || (fprintf(dev->fgpioval,"1\n") != sizeof("1\n")-1);
+#endif
 }
 
 int rno_g_cal_disable(rno_g_cal_dev_t * dev)
 {
   if (!dev) return 1;
   dev->enabled = 0;
+
+#ifdef USE_LIBGPIOS
+  return gpios_set_value(&dev->gpio,false);
+#else
   return (fprintf(dev->fgpioval,"0\n") != sizeof("0\n")-1) || (fprintf(dev->fgpiodir,"in\n") != sizeof("in\n")-1);
+#endif
 }
+
 
 int rno_g_cal_disable_no_handle(uint16_t gpio)
 {
+#ifdef USE_LIBGPIOS
+  gpios_line_t line;
+  //open as an input, that will turn it off :)
+  int ok = gpios_get_line_by_label("CAL_EN", &line, 0); 
+  gpios_release(&line);
+  return ok;
+#else
   char gpio_dir[128];
   snprintf(gpio_dir,sizeof(gpio_dir), gpio_dir_format, gpio);
 
@@ -191,6 +244,7 @@ int rno_g_cal_disable_no_handle(uint16_t gpio)
   int ret = fprintf(f,"in\n") != sizeof("in\n"-1);
   fclose(f);
   return ret;
+#endif
 }
 
 

--- a/src/rno-g-cal.c
+++ b/src/rno-g-cal.c
@@ -16,6 +16,7 @@
 
 #ifdef USE_LIBGPIOS
 #include "libgpios.h"
+#include <stdbool.h>
 #endif
 
 
@@ -39,7 +40,7 @@ struct rno_g_cal_dev
 #endif
 };
 
-const char valid_revs[] = "DEF";
+const char valid_revs[] = "DEFN";
 
 const uint8_t addr0 = 0x38;
 const uint8_t addr1 = 0x3f;
@@ -74,13 +75,15 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
     rev = toupper(rev);
   }
 
+#ifdef USE_LIBGPIOS
+  rev = 'N'; // overwrite
+#endif
+
   if (!strchr(valid_revs, rev))
   {
     fprintf(stderr, "rev%c is not valid!\n", rev);
     return NULL;
   }
-
-
 
 #ifndef USE_LIBGPIOS
   // make sure we have the gpio exported
@@ -108,7 +111,7 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
   int ok = gpios_get_line_by_label("CAL_EN", &line, GPIOS_OUTPUT);
   if (ok)
   {
-    fprintf("Could not open GPIO CAL_EN\n",);
+    fprintf(stderr, "Could not open GPIO CAL_EN\n");
     return NULL;
   }
 
@@ -133,7 +136,7 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
     return NULL;
   }
 
-#ifndef LIBGPIOS_H
+#ifndef USE_LIBGPIOS
   //open the gpio file
   FILE * fgpio = fopen(gpio_dir,"w");
   if (!fgpio)
@@ -169,7 +172,7 @@ rno_g_cal_dev_t * rno_g_cal_open(uint8_t bus, uint16_t gpio, char rev)
   dev->fgpiodir = fgpio;
   dev->fgpioval = fval;
 #else
-  memcpy(&dev->gpio,&line, sizeof(line);
+  memcpy(&dev->gpio, &line, sizeof(line));
 #endif
 
   dev->fd = fd;
@@ -251,9 +254,6 @@ int rno_g_cal_disable_no_handle(uint16_t gpio)
 }
 
 
-
-
-
 static int do_write(rno_g_cal_dev_t * dev, uint8_t addr, uint8_t reg, uint8_t val)
 {
 
@@ -316,9 +316,10 @@ static int do_readv(rno_g_cal_dev_t * dev, uint8_t addr, uint8_t reg, int N, uin
   return 0;
 }
 
+
 static int do_read(rno_g_cal_dev_t *dev, uint8_t addr, uint8_t reg, uint8_t * val)
 {
-  return do_readv(dev,addr,reg,1, val);
+  return do_readv(dev, addr, reg, 1, val);
 }
 
 
@@ -329,7 +330,11 @@ int rno_g_cal_setup(rno_g_cal_dev_t* dev)
   if (do_write(dev, addr0, config_reg,0x00)) return -errno;
   if (do_write(dev, addr1, output_reg,0x00)) return -errno;
   if (do_write(dev, addr1, config_reg,0x00)) return -errno;
+#ifdef USE_LIBGPIOS
+  dev->ch = (rno_g_calpulser_out_t) -1; //nothing selected yet (no RF output maps to the all-zero register state)
+#else
   dev->ch = RNO_G_CAL_NO_OUTPUT;
+#endif
   dev->mode = RNO_G_CAL_NO_SIGNAL;
   dev->atten = 63; //max, I think
   dev->setup = 1;
@@ -349,6 +354,9 @@ int rno_g_cal_set_pulse_mode(rno_g_cal_dev_t *dev, rno_g_calpulser_mode_t type)
     return -errno;
   }
 
+  if (type == RNO_G_CAL_NO_SIGNAL)
+    return 0;  // Do nothing?
+
   if (type == RNO_G_CAL_PULSER)
   {
     val|=0x40; //turn on pulser
@@ -357,15 +365,25 @@ int rno_g_cal_set_pulse_mode(rno_g_cal_dev_t *dev, rno_g_calpulser_mode_t type)
     {
       val&=(~0x08); //turn off VCO?
     }
+    else if (dev->rev=='N') //only one VCO for revN
+    {
+      val&=(~0x02); //turn off VCO?
+    }
     else
     {
       val&=(~0x03); // turn off VCO for revE
     }
   }
+  // Has to be either RNO_G_CAL_VCO or RNO_G_CAL_VCO2
   else if (dev->rev=='D') //only one VCO for revD
   {
     val&=(~0x40); //turn off pulser?
     val|=0x08; //turn on VCO?
+  }
+  else if (dev->rev=='N') //only one VCO for revN
+  {
+    val&=(~0x40); //turn off pulser?
+    val|=0x02; //turn on VCO?
   }
   else
   {
@@ -389,20 +407,54 @@ int rno_g_cal_select(rno_g_cal_dev_t * dev, rno_g_calpulser_out_t ch)
   uint8_t val0;
   uint8_t val1;
 
-  if (dev->setup && dev->ch ==  ch) return 0;
+  if (dev->setup && dev->ch == ch) return 0;
   if (do_read(dev, addr0, output_reg, &val0))
     return -errno;
 
   if (do_read(dev, addr1, output_reg, &val1))
     return -errno;
 
-  if (dev->rev >= 'E')
-  {
+  if (dev->rev == 'E' || dev->rev == 'F')
+  { //biases are active low
     val1 |= 0xc;
     if (do_write(dev, addr1, output_reg, val1))
       return -errno;
   }
+  else if (dev->rev == 'N') { //biases are active high
+    val1 &= (~0x1d);
+    if (do_write(dev, addr1, output_reg, val1))
+      return -errno;
+  }
 
+#ifdef USE_LIBGPIOS
+  uint8_t bias_bit;
+  switch (ch)
+  {
+    case RNO_G_CAL_RF0:
+      val0 |= 0x02;  //set out switch 0 to 1
+      val1 |= 0x20;  //set out switch 1 to 1
+      bias_bit = 0x01; //en_bias0
+      break;
+    case RNO_G_CAL_RF1:
+      val0 |= 0x02;  //set out switch 0 to 1
+      val1 &= ~0x20; //set out switch 1 to 0
+      bias_bit = 0x04; //en_bias1
+      break;
+    case RNO_G_CAL_RF2:
+      val0 &= ~0x02; //set out switch 0 to 0
+      val1 |= 0x80;  //set out switch 2 to 1
+      bias_bit = 0x08; //en_bias2
+      break;
+    case RNO_G_CAL_RF3:
+      val0 &= ~0x02; //set out switch 0 to 0
+      val1 &= ~0x80; //set out switch 2 to 0
+      bias_bit = 0x10; //en_bias3
+      break;
+    default:
+      fprintf(stderr, "output %d is not a valid output, please select RF0-RF3\n", (int) ch);
+      return 1;
+  }
+#else
   if (ch == RNO_G_CAL_COAX)
   {
     val0 &= (~0x02);
@@ -443,10 +495,18 @@ int rno_g_cal_select(rno_g_cal_dev_t * dev, rno_g_calpulser_out_t ch)
     val1 &= (~0x80);
     val1 &= (~0x20);
   }
+#endif
 
 
   if (do_write(dev, addr0, output_reg, val0)) return -errno;
   if (do_write(dev, addr1, output_reg, val1)) return -errno;
+
+#ifdef USE_LIBGPIOS
+  //enable the bias for the selected output (matches Python reference: re-read + OR in the bias bit)
+  val1 |= bias_bit;
+  if (do_write(dev, addr1, output_reg, val1)) return -errno;
+#endif
+
   if (dev->setup) dev->ch = ch;
   return 0;
 }

--- a/src/rno-g-cal.h
+++ b/src/rno-g-cal.h
@@ -13,7 +13,7 @@ extern "C"
 
 typedef struct rno_g_cal_dev rno_g_cal_dev_t;
 
-rno_g_cal_dev_t * rno_g_cal_open(uint8_t i2c_bus,uint16_t gpio, char board_rev);
+rno_g_cal_dev_t * rno_g_cal_open(uint8_t i2c_bus, uint16_t gpio, char board_rev);
 
 int rno_g_cal_close(rno_g_cal_dev_t* dev);
 
@@ -43,4 +43,3 @@ void rno_g_cal_enable_dbg(rno_g_cal_dev_t * dev, int dbg);
 #endif
 
 #endif
-

--- a/src/rno-g-cal.h
+++ b/src/rno-g-cal.h
@@ -29,6 +29,8 @@ int rno_g_cal_setup(rno_g_cal_dev_t* dev);
 
 int rno_g_cal_read_temp(rno_g_cal_dev_t * dev, float *T);
 
+int rno_g_cal_read_humidity(rno_g_cal_dev_t * dev, float *humidity);
+
 int rno_g_cal_select(rno_g_cal_dev_t * dev, rno_g_calpulser_out_t ch);
 
 int rno_g_cal_set_atten(rno_g_cal_dev_t * dev, uint8_t atten); //attenuation, in half dB steps. 0 = no attenuation, 63=31.5 dB

--- a/src/rno-g.h
+++ b/src/rno-g.h
@@ -266,7 +266,17 @@ typedef struct rno_g_radiant_voltages
   uint16_t V_RightMon;
 } rno_g_radiant_voltages_t;
 
+#ifdef USE_LIBGPIOS
+typedef enum
+{
+  RNO_G_CAL_RF0 = 0,
+  RNO_G_CAL_RF1,
+  RNO_G_CAL_RF2,
+  RNO_G_CAL_RF3
+} rno_g_calpulser_out_t;
 
+#define RNO_G_CALPULSER_OUT_STRS {"RF0", "RF1", "RF2", "RF3"}
+#else
 typedef enum
 {
   RNO_G_CAL_NO_OUTPUT = 0,
@@ -275,7 +285,20 @@ typedef enum
   RNO_G_CAL_FIB1
 } rno_g_calpulser_out_t;
 
-#define RNO_G_CALPULSER_OUT_STRS {"none","coax","fiber0", "fiber1"}
+#define RNO_G_CALPULSER_OUT_STRS {"none", "coax", "fiber0", "fiber1"}
+#endif
+
+
+#ifdef USE_LIBGPIOS
+typedef enum
+{
+  RNO_G_CAL_NO_SIGNAL = 0,
+  RNO_G_CAL_PULSER,
+  RNO_G_CAL_VCO,
+} rno_g_calpulser_mode_t;
+
+#define RNO_G_CALPULSER_MODE_STRS {"none", "pulser","vco"}
+#else
 
 typedef enum
 {
@@ -285,7 +308,8 @@ typedef enum
   RNO_G_CAL_VCO2
 } rno_g_calpulser_mode_t;
 
-#define RNO_G_CALPULSER_MODE_STRS {"none","pulser","vco", "vco2"}
+#define RNO_G_CALPULSER_MODE_STRS {"none", "pulser", "vco", "vco2"}
+#endif
 
 
 typedef struct rno_g_calpulser_info

--- a/test/cal-cmd.c
+++ b/test/cal-cmd.c
@@ -1,55 +1,58 @@
-#include "rno-g-cal.h" 
+#include "rno-g-cal.h"
 
-#include <stdio.h> 
-#include <stdlib.h> 
-#include <unistd.h> 
-#include <string.h> 
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 
 
 
-void usage() 
+void usage()
 {
-  fprintf(stderr,"Usage: rno-g-cal-cmd [--bus=2] [--gpio=49] [--rev=D] CMD0 [VAL]  [ CMD1 ...] \n"); 
-  fprintf(stderr,"      CMD can be: off, on, setup, temp, select-coax, select-fiber0, select-fiber1, select-none , atten val, pulse, vco, sleep N, wait\n"); 
-  fprintf(stderr,"      Up to 1024 commands are supported\n"); 
+  fprintf(stderr,"Usage: rno-g-cal-cmd [--bus=2] [--gpio=49] [--rev=D] CMD0 [VAL]  [ CMD1 ...] \n");
+  fprintf(stderr,"      CMD can be: off, on, setup, temp, select-coax, select-fiber0, select-fiber1, select-none , atten val, pulse, vco, sleep N, wait\n");
+  fprintf(stderr,"      Up to 1024 commands are supported\n");
 }
 
-const char * valid_cmds[] = {"off","on","setup","temp","select-coax","select-fiber0","select-fiber1","select-none", "atten", "pulse", "vco","vco2", "sleep","wait"}; 
-enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_COAX, CMD_FIB0, CMD_FIB1, CMD_NONE, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_VCO2, CMD_SLEEP, CMD_WAIT} e_cmds; 
+const char * valid_cmds[] = {"off","on","setup","temp","select-coax","select-fiber0","select-fiber1","select-none", "atten", "pulse", "vco","vco2", "sleep","wait"};
+enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_COAX, CMD_FIB0, CMD_FIB1, CMD_NONE, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_VCO2, CMD_SLEEP, CMD_WAIT} e_cmds;
 
-int is_valid(const char * cmd) 
+int is_valid(const char * cmd)
 {
   for (int i = 0;  i <  (int) (sizeof(valid_cmds)/ sizeof(*valid_cmds)) ; i++)
   {
-    if (!strcmp(cmd,valid_cmds[i])) return i; 
+    if (!strcmp(cmd,valid_cmds[i])) return i;
 
   }
 
-  return -1; 
+  return -1;
 
 }
 
-int main (int nargs, char ** args) 
+int main (int nargs, char ** args)
 {
 
-  if (nargs <2) 
+  if (nargs <2)
   {
-    usage(); 
-    exit(1); 
+    usage();
+    exit(1);
   }
 
+#ifdef USE_LIBGPIOS
+  uint8_t bus = 1; //refN
+else
+  uint8_t bus = 2; //refE
+#endif
+  int dbg = 0;
+  uint16_t gpio = 49;
+  char rev='D';
 
-  uint8_t bus = 2; 
-  int dbg = 0; 
-  uint16_t gpio = 49; 
-  char rev='D'; 
-  
-  static uint8_t cmds[1024]; 
-  static uint16_t vals[1024]; 
-  
-  int ncmds = 0; 
+  static uint8_t cmds[1024];
+  static uint16_t vals[1024];
 
-  for (int iarg = 1; iarg < nargs; iarg++) 
+  int ncmds = 0;
+
+  for (int iarg = 1; iarg < nargs; iarg++)
   {
     if (!strcmp(args[iarg],"--bus"))
     {
@@ -58,9 +61,9 @@ int main (int nargs, char ** args)
 
     else if (!strcmp(args[iarg],"--debug"))
     {
-      dbg =1; 
+      dbg =1;
     }
- 
+
     else if (!strcmp(args[iarg],"--gpio"))
     {
       gpio = atoi(args[++iarg]);
@@ -69,84 +72,83 @@ int main (int nargs, char ** args)
     {
       rev = args[++iarg][0];
     }
-    //argument to atten? 
+    //argument to atten?
     else if (ncmds && ( (cmds[ncmds-1] == CMD_ATTEN) || (cmds[ncmds-1] == CMD_SLEEP)))
     {
-      vals[ncmds-1] = atoi(args[iarg]); 
+      vals[ncmds-1] = atoi(args[iarg]);
     }
-    else 
+    else
     {
-      int cmdcode = is_valid(args[iarg]); 
-      if (cmdcode < 0) 
+      int cmdcode = is_valid(args[iarg]);
+      if (cmdcode < 0)
       {
-        usage(); 
-        return 1; 
+        usage();
+        return 1;
       }
 
-      if (ncmds >= (int) sizeof(cmds) )break; // only support up to 1024 commands... 
-      cmds[ncmds++] = cmdcode; 
+      if (ncmds >= (int) sizeof(cmds) )break; // only support up to 1024 commands...
+      cmds[ncmds++] = cmdcode;
 
     }
   }
 
-  rno_g_cal_dev_t * dev = rno_g_cal_open(bus,gpio, rev); 
+  rno_g_cal_dev_t * dev = rno_g_cal_open(bus, gpio, rev);
 
-  rno_g_cal_enable_dbg(dev,dbg); 
+  rno_g_cal_enable_dbg(dev, dbg);
 
-  for (int i = 0; i < ncmds; i++) 
+  for (int i = 0; i < ncmds; i++)
   {
-    float T; 
+    float T;
     switch (cmds[i])
     {
-      case CMD_OFF: 
-        rno_g_cal_disable(dev); 
-        break; 
-      case CMD_ON: 
-        rno_g_cal_enable(dev); 
-        break; 
-      case CMD_WAIT: 
-        rno_g_cal_wait_ready(dev); 
-        break; 
- 
-      case CMD_SETUP: 
-        rno_g_cal_setup(dev); 
-        break; 
-      case CMD_TEMP: 
-        rno_g_cal_read_temp(dev,&T); 
-        printf("Temperature: %f\n", T); 
-        break; 
-      case CMD_COAX: 
-        rno_g_cal_select(dev, RNO_G_CAL_COAX); 
-        break; 
-      case CMD_FIB0: 
-        rno_g_cal_select(dev, RNO_G_CAL_FIB0); 
-        break; 
-      case CMD_FIB1: 
-        rno_g_cal_select(dev, RNO_G_CAL_FIB1); 
-        break; 
-     case CMD_NONE: 
-        rno_g_cal_select(dev, RNO_G_CAL_NO_OUTPUT); 
-        break; 
-     case CMD_ATTEN: 
-        rno_g_cal_set_atten(dev, vals[i]); 
-        break; 
-     case CMD_PULSE: 
+      case CMD_OFF:
+        rno_g_cal_disable(dev);
+        break;
+      case CMD_ON:
+        rno_g_cal_enable(dev);
+        break;
+      case CMD_WAIT:
+        rno_g_cal_wait_ready(dev);
+        break;
+
+      case CMD_SETUP:
+        rno_g_cal_setup(dev);
+        break;
+      case CMD_TEMP:
+        rno_g_cal_read_temp(dev,&T);
+        printf("Temperature: %f\n", T);
+        break;
+      case CMD_COAX:
+        rno_g_cal_select(dev, RNO_G_CAL_COAX);
+        break;
+      case CMD_FIB0:
+        rno_g_cal_select(dev, RNO_G_CAL_FIB0);
+        break;
+      case CMD_FIB1:
+        rno_g_cal_select(dev, RNO_G_CAL_FIB1);
+        break;
+     case CMD_NONE:
+        rno_g_cal_select(dev, RNO_G_CAL_NO_OUTPUT);
+        break;
+     case CMD_ATTEN:
+        rno_g_cal_set_atten(dev, vals[i]);
+        break;
+     case CMD_PULSE:
         rno_g_cal_set_pulse_mode(dev, RNO_G_CAL_PULSER);
-        break; 
-     case CMD_VCO: 
+        break;
+     case CMD_VCO:
         rno_g_cal_set_pulse_mode(dev, RNO_G_CAL_VCO);
-        break; 
-     case CMD_VCO2: 
+        break;
+     case CMD_VCO2:
         rno_g_cal_set_pulse_mode(dev, RNO_G_CAL_VCO2);
-        break; 
-     case CMD_SLEEP: 
-        sleep(vals[i]); 
-        break; 
+        break;
+     case CMD_SLEEP:
+        sleep(vals[i]);
+        break;
     }
   }
 
-  rno_g_cal_close(dev); 
+  rno_g_cal_close(dev);
 
-  return 0; 
-} 
-
+  return 0;
+}

--- a/test/cal-cmd.c
+++ b/test/cal-cmd.c
@@ -10,12 +10,21 @@
 void usage()
 {
   fprintf(stderr,"Usage: rno-g-cal-cmd [--bus=2] [--gpio=49] [--rev=D] CMD0 [VAL]  [ CMD1 ...] \n");
+#ifdef USE_LIBGPIOS
+  fprintf(stderr,"      CMD can be: off, on, setup, temp, select-rf0, select-rf1, select-rf2, select-rf3, atten val, pulse, vco, sleep N, wait\n");
+#else
   fprintf(stderr,"      CMD can be: off, on, setup, temp, select-coax, select-fiber0, select-fiber1, select-none , atten val, pulse, vco, sleep N, wait\n");
+#endif
   fprintf(stderr,"      Up to 1024 commands are supported\n");
 }
 
+#ifdef USE_LIBGPIOS
+const char * valid_cmds[] = {"off","on","setup","temp","select-rf0","select-rf1","select-rf2","select-rf3", "atten", "pulse", "vco","vco2", "sleep","wait"};
+enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_RF0, CMD_RF1, CMD_RF2, CMD_RF3, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_VCO2, CMD_SLEEP, CMD_WAIT} e_cmds;
+#else
 const char * valid_cmds[] = {"off","on","setup","temp","select-coax","select-fiber0","select-fiber1","select-none", "atten", "pulse", "vco","vco2", "sleep","wait"};
 enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_COAX, CMD_FIB0, CMD_FIB1, CMD_NONE, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_VCO2, CMD_SLEEP, CMD_WAIT} e_cmds;
+#endif
 
 int is_valid(const char * cmd)
 {
@@ -39,9 +48,9 @@ int main (int nargs, char ** args)
   }
 
 #ifdef USE_LIBGPIOS
-  uint8_t bus = 1; //refN
-else
-  uint8_t bus = 2; //refE
+  uint8_t bus = 1; //revN
+#else
+  uint8_t bus = 2; //revE
 #endif
   int dbg = 0;
   uint16_t gpio = 49;
@@ -118,6 +127,20 @@ else
         rno_g_cal_read_temp(dev,&T);
         printf("Temperature: %f\n", T);
         break;
+#ifdef USE_LIBGPIOS
+      case CMD_RF0:
+        rno_g_cal_select(dev, RNO_G_CAL_RF0);
+        break;
+      case CMD_RF1:
+        rno_g_cal_select(dev, RNO_G_CAL_RF1);
+        break;
+      case CMD_RF2:
+        rno_g_cal_select(dev, RNO_G_CAL_RF2);
+        break;
+      case CMD_RF3:
+        rno_g_cal_select(dev, RNO_G_CAL_RF3);
+        break;
+#else
       case CMD_COAX:
         rno_g_cal_select(dev, RNO_G_CAL_COAX);
         break;
@@ -130,6 +153,7 @@ else
      case CMD_NONE:
         rno_g_cal_select(dev, RNO_G_CAL_NO_OUTPUT);
         break;
+#endif
      case CMD_ATTEN:
         rno_g_cal_set_atten(dev, vals[i]);
         break;

--- a/test/cal-cmd.c
+++ b/test/cal-cmd.c
@@ -11,19 +11,19 @@ void usage()
 {
   fprintf(stderr,"Usage: rno-g-cal-cmd [--bus=2] [--gpio=49] [--rev=D] CMD0 [VAL]  [ CMD1 ...] \n");
 #ifdef USE_LIBGPIOS
-  fprintf(stderr,"      CMD can be: off, on, setup, temp, select-rf0, select-rf1, select-rf2, select-rf3, atten val, pulse, vco, sleep N, wait\n");
+  fprintf(stderr,"      CMD can be: off, on, setup, temp, humidity, select-rf0, select-rf1, select-rf2, select-rf3, atten val, pulse, vco, sleep N, wait\n");
 #else
-  fprintf(stderr,"      CMD can be: off, on, setup, temp, select-coax, select-fiber0, select-fiber1, select-none , atten val, pulse, vco, sleep N, wait\n");
+  fprintf(stderr,"      CMD can be: off, on, setup, temp, humidity, select-coax, select-fiber0, select-fiber1, select-none , atten val, pulse, vco, vco2, sleep N, wait\n");
 #endif
   fprintf(stderr,"      Up to 1024 commands are supported\n");
 }
 
 #ifdef USE_LIBGPIOS
-const char * valid_cmds[] = {"off","on","setup","temp","select-rf0","select-rf1","select-rf2","select-rf3", "atten", "pulse", "vco","vco2", "sleep","wait"};
-enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_RF0, CMD_RF1, CMD_RF2, CMD_RF3, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_VCO2, CMD_SLEEP, CMD_WAIT} e_cmds;
+const char * valid_cmds[] = {"off","on","setup","temp","humidity","select-rf0","select-rf1","select-rf2","select-rf3", "atten", "pulse", "vco", "sleep","wait"};
+enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_HUMIDITY, CMD_RF0, CMD_RF1, CMD_RF2, CMD_RF3, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_SLEEP, CMD_WAIT} e_cmds;
 #else
-const char * valid_cmds[] = {"off","on","setup","temp","select-coax","select-fiber0","select-fiber1","select-none", "atten", "pulse", "vco","vco2", "sleep","wait"};
-enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_COAX, CMD_FIB0, CMD_FIB1, CMD_NONE, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_VCO2, CMD_SLEEP, CMD_WAIT} e_cmds;
+const char * valid_cmds[] = {"off","on","setup","temp","humidity","select-coax","select-fiber0","select-fiber1","select-none", "atten", "pulse", "vco","vco2", "sleep","wait"};
+enum { CMD_OFF, CMD_ON, CMD_SETUP, CMD_TEMP, CMD_HUMIDITY, CMD_COAX, CMD_FIB0, CMD_FIB1, CMD_NONE, CMD_ATTEN, CMD_PULSE, CMD_VCO, CMD_VCO2, CMD_SLEEP, CMD_WAIT} e_cmds;
 #endif
 
 int is_valid(const char * cmd)
@@ -108,6 +108,7 @@ int main (int nargs, char ** args)
   for (int i = 0; i < ncmds; i++)
   {
     float T;
+    float H;
     switch (cmds[i])
     {
       case CMD_OFF:
@@ -126,6 +127,10 @@ int main (int nargs, char ** args)
       case CMD_TEMP:
         rno_g_cal_read_temp(dev,&T);
         printf("Temperature: %f\n", T);
+        break;
+      case CMD_HUMIDITY:
+        rno_g_cal_read_humidity(dev,&H);
+        printf("Humidity: %f\n", H);
         break;
 #ifdef USE_LIBGPIOS
       case CMD_RF0:
@@ -163,9 +168,11 @@ int main (int nargs, char ** args)
      case CMD_VCO:
         rno_g_cal_set_pulse_mode(dev, RNO_G_CAL_VCO);
         break;
+#ifndef USE_LIBGPIOS
      case CMD_VCO2:
         rno_g_cal_set_pulse_mode(dev, RNO_G_CAL_VCO2);
         break;
+#endif
      case CMD_SLEEP:
         sleep(vals[i]);
         break;


### PR DESCRIPTION
Work in progress


- Using `USE_LIBGPIOS` to differentiate between ref E and ref N. Maybe should its own macro/runtime variable...
- For the DAQ, the i2c bus is specified in the run config (rno-g-ice-software) - no mods necessary here.

Missing:

- [x] Reflect changes in "outputs"
- [x] add humidity read function