### PR TITLE
Remove stray memset that zeroed v0 headers after reading

### DIFF
--- a/src/rno-g.c
+++ b/src/rno-g.c
@@ -218,7 +218,6 @@ int rno_g_header_read(rno_g_file_handle_t h, rno_g_header_t *header)
       //I THINK we can just get away with zeroing and reading hdv0 amount
       memset(header,0, sizeof(*header));
       rd = do_read(h,sizeof(rno_g_header_v0_t),header, &sum);
-      memset(header,0, sizeof(*header));
       break;
     }
     case 1:


### PR DESCRIPTION
Fixes #13.

`rno_g_header_read` zeroed the output struct a second time after reading the v0 payload into it, so any v0 header packet was silently returned all-zero (the checksum is computed on the bytes as read, so it still validated). This removes the stray second `memset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)